### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,7 @@
 name: Portfolio CI/CD
 run-name: CI/CD
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/josecarlosgonzalezv/web-portfolio/security/code-scanning/1](https://github.com/josecarlosgonzalezv/web-portfolio/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block specifying the minimal permissions the job needs, instead of relying on the repository/organization defaults. Since there is only one job, adding `permissions:` at the top (root) level will apply to all jobs; you could also define it under `portfolio-build-and-deploy:` only. The workflow needs to read and write repository contents (for tags, releases, and `gh-pages` deployment). The minimum safe set here is `contents: write`. If you know you only need read for packages, etc., you can omit those.

Best minimal change without altering functionality: add a root-level `permissions:` section between `run-name:` and `on:` in `.github/workflows/cicd.yml`, with `contents: write`. This documents the requirement and constrains the token to that scope, while still allowing `git push`, `actions/create-release`, and `actions-gh-pages` to work. No additional imports or methods are needed; this is purely a YAML configuration update.

Concretely, in `.github/workflows/cicd.yml`, insert:

```yaml
permissions:
  contents: write
```

after line 2 (`run-name: CI/CD`) and before line 4 (`on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
